### PR TITLE
fixed findByMatricNumber unit test to fail in case of failure

### DIFF
--- a/src/test/java/data/repositories/StudentRepositoryImplTest.java
+++ b/src/test/java/data/repositories/StudentRepositoryImplTest.java
@@ -2,6 +2,7 @@ package data.repositories;
 
 import data.models.Student;
 import exceptions.HostelManagementException;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -43,7 +44,7 @@ class StudentRepositoryImplTest {
             assertThat(student.getFirstName(), equalTo("Ehis"));
         }
         catch (HostelManagementException exception){
-            exception.printStackTrace();
+            Assertions.fail(exception);
         }
     }
 

--- a/src/test/java/data/repositories/StudentRepositoryImplTest.java
+++ b/src/test/java/data/repositories/StudentRepositoryImplTest.java
@@ -58,7 +58,7 @@ class StudentRepositoryImplTest {
     @Test
     void delete() throws Exception {
         studentStudentRepository.delete(studentTwo);
-        assertThat(studentStudentRepository.findById("PSC1004300"), is(Optional.empty()));
+        assertThat(studentStudentRepository.findById("PSC1004300").isEmpty(), is(true));
     }
 
     @Test
@@ -70,6 +70,6 @@ class StudentRepositoryImplTest {
     @Test
     void testCanDeleteById() throws Exception {
         studentStudentRepository.delete("PSC1004300");
-        assertThat(studentStudentRepository.findById("PSC1004300"), is(Optional.empty()));
+        assertThat(studentStudentRepository.findById("PSC1004300").isEmpty(), is(true));
     }
 }


### PR DESCRIPTION
During the code review, I found that you only print the stack trace in case the finding by matric number fails, but the unit test will still be successful. Even if the console shows the error it is a bad practice for example in a CI the build remains successful and no one notices the output. If the assertion fails the unit test also must fail.